### PR TITLE
Removed previous hack in mailer.

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp/Auth/Login.php
+++ b/library/Zend/Mail/Protocol/Smtp/Auth/Login.php
@@ -59,19 +59,6 @@ class Login extends Smtp
      */
     public function __construct($host = '127.0.0.1', $port = null, $config = null)
     {
-        /*
-         * This is a tempoarty fix that orders the parmeters correctly. An array
-         * is being passed in the first parameter when it should be split over
-         * the three parameters, it look like call_user_func() is being used
-         * instead of call_user_func_array().
-         * 
-         * @author Ronny Srnka <ronny.srnka@gmail.com>
-         * @since 5 July 2012
-         */
-        $port = $host[1];
-        $config = $host[2];
-        $host = $host[0];
-
         // Did we receive a configuration array?
         $origConfig = $config;
         if (is_array($host)) {


### PR DESCRIPTION
The reason for the original hack in the Zend\Mail\Protocol\Smtp\Auth\Login class has been fixed in beta5, removing fix.

issue A24Group/Triage#309
