### PR TITLE
Custom not found message in the RouteNotFoundStrategy.

### DIFF
--- a/library/Zend/Mvc/View/RouteNotFoundStrategy.php
+++ b/library/Zend/Mvc/View/RouteNotFoundStrategy.php
@@ -72,6 +72,13 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
     protected $reason = false;
 
     /**
+     * The not found message to be passed along to the view strategy and renderer via the ViewModel.
+     * 
+     * @var string
+     */
+    protected $notFoundMessage = "";
+
+    /**
      * Attach the aggregate to the specified event manager
      *
      * @param  EventManagerInterface $events
@@ -166,6 +173,29 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
     }
 
     /**
+     * Sets the not found message for the strategy.
+     *
+     * @author Jaco Nel <jaco.nel@a24group.com>
+     * @since 03 Aug 2012
+     *
+     * @param string $message The not found message
+     */
+    public function setNotFoundMessage($message)
+    {
+        $this->notFoundMessage = trim($message);
+    }
+
+    /**
+     * Get the not found message for the strategy.
+     *
+     * @return string The not found message
+     */
+    public function getNotFoundMessage()
+    {
+        return $this->notFoundMessage;
+    }
+
+    /**
      * Detect if an error is a 404 condition
      *
      * If a "controller not found" or "invalid controller" error type is
@@ -219,7 +249,7 @@ class RouteNotFoundStrategy implements ListenerAggregateInterface
         }
 
         $model = new ViewModel();
-        $model->setVariable('message', 'Page not found.');
+        $model->setVariable('message', $this->getNotFoundMessage());
         $model->setTemplate($this->getNotFoundTemplate());
 
         // If displaying reasons, inject the reason

--- a/library/Zend/Mvc/View/ViewManager.php
+++ b/library/Zend/Mvc/View/ViewManager.php
@@ -438,6 +438,7 @@ class ViewManager implements ListenerAggregateInterface
 
         $displayNotFoundReason = false;
         $notFoundTemplate      = '404';
+        $notFoundMessage       = 'Page not found.';
 
         if (isset($this->config['display_not_found_reason'])) {
             $displayNotFoundReason = $this->config['display_not_found_reason'];
@@ -445,9 +446,13 @@ class ViewManager implements ListenerAggregateInterface
         if (isset($this->config['not_found_template'])) {
             $notFoundTemplate = $this->config['not_found_template'];
         }
+        if (isset($this->config['not_found_message'])) {
+            $notFoundMessage = $this->config['not_found_message'];
+        }
 
         $this->routeNotFoundStrategy->setDisplayNotFoundReason($displayNotFoundReason);
         $this->routeNotFoundStrategy->setNotFoundTemplate($notFoundTemplate);
+        $this->routeNotFoundStrategy->setNotFoundMessage($notFoundMessage);
 
         $this->services->setService('RouteNotFoundStrategy', $this->routeNotFoundStrategy);
         $this->services->setAlias('Zend\Mvc\View\RouteNotFoundStrategy', 'RouteNotFoundStrategy');


### PR DESCRIPTION
Update the RouteNotFoundStrategy to allow configuring the not found message.

Changes made to allow us to specify the 404 not found message
from configuration in the view manager.

issue A24Group/Triage#513
